### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,23 @@
 
 ![Use Trex](https://cdn.discordapp.com/attachments/727169454667989016/728363543614980116/ajio.gif)
 
-### What is Trex?
+## About
 
-is a Package management for deno similar to npm but maintaining the deno philosophy. packages are cached and only one `import_map.json` file is generated.
+Trex is a package management tool for deno similar to npm but keeping close to the deno philosophy. Packages are cached and only one `import_map.json` file is generated.
 
 ```javascript
 // import_map.json
 
 {
-    "imports":  {
-	"http/":  "https://deno.land/std/http/"
-    }
+  "imports":  {
+    "http/":  "https://deno.land/std/http/"
+  }
 }
 ```
 
-For more information about the import maps in deno [import maps](https://deno.land/manual/linking_to_external_code/import_maps)
+For more information about the import maps in deno see [import maps](https://deno.land/manual/linking_to_external_code/import_maps).
 
-# Content
+## Additional topics
 
 - [Proxy](docs/proxy.md)
 
@@ -59,25 +59,25 @@ For more information about the import maps in deno [import maps](https://deno.la
 
 - [How can I add my tool to make it available on Trex?](docs/add_tool.md)
 
-### installation:
+## Installation
 
-install from [nest.land](https://nest.land/) module registry
+Install from the [nest.land](https://nest.land/) module registry:
 
-```sh
-$  deno install -A --unstable -n trex https://x.nest.land/Trex@latest/cli.ts
+```console
+deno install -A --unstable -n trex https://x.nest.land/Trex@latest/cli.ts
 ```
 
-> **note**: You should have the last version 1.0.0 >= of deno for no errors.
+> **note**: Works with deno >= 1.0.0.
 
-or in your terminal you can write
+Or from deno.land:
 
-```sh
-$  deno install -A --unstable -n trex https://deno.land/x/trex/cli.ts
+```console
+deno install -A --unstable -n trex https://deno.land/x/trex/cli.ts
 ```
 
 **we shorten the install command so it's not that long**
 
-The resources that Trex uses are:
+The permissions that Trex uses are:
 
 - --allow-net
 - --allow-read
@@ -85,85 +85,87 @@ The resources that Trex uses are:
 - --allow-run
 - --allow-env
 
-you can give those permissions explicitly
+You can give those permissions explicitly.
 
-### update Trex using
+## Updating Trex
 
-```sh
-$  deno install -f -A --unstable -n trex https://deno.land/x/trex/cli.ts
+Install new version with the `-f` flag:
+
+```console
+deno install -f -A --unstable -n trex https://deno.land/x/trex/cli.ts
 ```
 
-**or use:**
+Or use the `update` command:
 
-```sh
-$ trex update
+```console
+trex update
 ```
 
-for versions 0.2.0 or higher.
+Note: available for versions 0.2.0 or higher.
 
-check for the installation of the Trex tool writing in the terminal:
+Verify the installation of Trex:
 
-```sh
-$  trex --version
+```console
+trex --version
 ```
 
-and the console should presente the Trex version.
+and the console should print the Trex version.
 
-for any help of the commands of Trex write:
+For help on the commands that Trex provides, use:
 
-```sh
-$  trex --help
+```console
+trex --help
 ```
 
-for a better implementation of this tool you can use the tool Commands of deno [Commands](https://deno.land/x/commands)
+For a better implementation of this tool you can use the [Commands](https://deno.land/x/commands) utility.
 
-# How to use
+## Usage
 
-in your command line write:
+### Installing from deno.land
 
-```sh
-$ trex install --map fs http fmt
+Install the `fs`, `http` and `fmt` modules from std:
+
+```console
+trex install --map fs http fmt
 ```
 
-> **note**: you can use **trex i --map fs http fmt**
+> **note**: you can use `trex i --map fs http fmt`
 
 `--map` installs packages from the standard library and those hosted at `deno.land/x`
 
-<details><summary>install package from nest.land or a repository (click me)</summary>
-<p>
+### Installing from nest.land
 
-Install a package hosted on [nest.land](https://nest.land/gallery)
+Install a package hosted on [nest.land](https://nest.land/gallery):
 
-```sh
-$ trex install --nest opine@0.13.0
+```console
+trex install --nest opine@0.13.0
 ```
 
-> **note**: if you install a package using nest.land you must specify the version, example: `$ Trex i --nest opine@0.13.0`
+> **note**: if you want to install a package using nest.land you must specify a version explicitly as above
 
-you can install packages from the standard deno library hosted in nest.land specifying the package and the version.
+You can install packages from std hosted in nest.land by specifying the package and the version:
 
-```sh
-$ trex install --nest fs@0.61.0
+```console
+trex install --nest fs@0.61.0
 ```
 
-Install a package from some repository
+### Installing from a repository
 
-```sh
-$ trex install --pkg [user]/[repo or repo@tag]/[path/to/file] [packageName]
+```console
+trex install --pkg [user]/[repo or repo@tag]/[path/to/file] [packageName]
 ```
 
-example:
+Example:
 
-```sh
-$ trex install --pkg oakserver/oak/mod.ts oak
+```console
+trex install --pkg oakserver/oak/mod.ts oak
 ```
 
-this downloads oak directly from its repository
+The above downloads oak directly from its repository.
 
-</p>
-</details>
+### Example import map
 
-an import_map.json file will be created with the following.
+All installation methods produce an import_map.json file:
 
 ```json
 {
@@ -175,97 +177,27 @@ an import_map.json file will be created with the following.
 }
 ```
 
-# example.
+### Downloading packages
 
-create a test file
+Download all the packages listed in the `import_map.json` similar to `npm install`:
 
-```javascript
-// server.ts
-import { serve } from "http/server.ts";
-import { green } from "fmt/colors.ts";
-
-const server = serve({ port: 8000 });
-console.log(green("http://localhost:8000/"));
-
-for await (const req of server) {
-  req.respond({ body: "Hello World\n" });
-}
+```console
+trex install
 ```
 
-run in terminal
+### Adding custom packages
 
-```sh
-$ deno run --allow-net --importmap=import_map.json --unstable server.ts
+Install a package from a custom URL source:
+
+```console
+trex --custom React=https://dev.jspm.io/react/index.js
 ```
 
-> **note**: it is important to use **--importmap=import_map.json --unstable**
-
-### using third party packages
-
-example using [oak](https://deno.land/x/oak)
-
-```sh
-$ trex i --map oak
-```
-
-in import_map.json
+`import_map.json`:
 
 ```json
 {
   "imports": {
-    "fs/": "https://deno.land/std/fs/",
-    "http/": "https://deno.land/std/http/",
-    "fmt/": "https://deno.land/std/fmt/",
-    "oak": "https://deno.land/x/oak/mod.ts"
-  }
-}
-```
-
-> **note**: third party packages are added using **mod.ts**
-
-in server.ts
-
-```javascript
-// server.ts
-import { Application } from "oak";
-
-const app = new Application();
-
-app.use((ctx) => {
-  ctx.response.body = "Hello World!";
-});
-
-await app.listen({ port: 8000 });
-```
-
-run in terminal
-
-```sh
-$ deno run --allow-net --importmap=import_map.json --unstable server.ts
-```
-
-### download packages from an `import_map.json` file.
-
-```sh
-$ trex install
-```
-
-this downloads all the packages listed in the `import_map.json` similar to `npm install`
-
-### add custom package
-
-in your command line write:
-
-```sh
-$ trex --custom React=https://dev.jspm.io/react/index.js
-```
-
-in import_map.json
-
-```json
-{
-  "imports": {
-    "fs/": "https://deno.land/std/fs/",
     "http/": "https://deno.land/std/http/",
     "fmt/": "https://deno.land/std/fmt/",
     "oak": "https://deno.land/x/oak/mod.ts",
@@ -274,35 +206,37 @@ in import_map.json
 }
 ```
 
-### install tools like [velociraptor](https://github.com/umbopepato/velociraptor) or [Commands](https://deno.land/x/commands)
+### Installing global scripts (cmdline tools etc.)
 
-[list of tools you can install](https://crewdevio.github.io/Trex-tools/)
+Trex allows installing executable scripts from its database, for example:
 
-in your command line write:
+- [velociraptor](https://github.com/umbopepato/velociraptor)
+- [Commands](https://deno.land/x/commands)
 
-```sh
-$ trex getTool Commands
+[List of installable tools](https://crewdevio.github.io/Trex-tools/)
+
+Use the `getTool` subcommand:
+
+```console
+trex getTool Commands
 ```
 
-this will install the tool
+> **note**: If you are a linux/MacOs user you'll have to specificate the PATH manually to use tools: **`export PATH="/home/username/.deno/bin:\$PATH"`**
 
-> **note**: If you are a linux/MacOs user you'll have to specificate the PATH manually when the tool gets installed the will appear in your terminal **export PATH="/home/username/.deno/bin:\$PATH"**
+### Deleting packages
 
-### delete a package
 
-in your command line write:
-
-```sh
-$ trex delete React
+```console
+trex delete React
 ```
 
-to remove a specific version from the cache and import_map.json, it only works with standard packages and those installed from `deno.land/x`
+Remove a specific version from the cache and the `import_map.json` file:
 
-```sh
-$ trex delete fs@0.52.0
+```console
+trex delete fs@0.52.0
 ```
 
-in import_map.json
+`import_map.json`:
 
 ```json
 {
@@ -315,19 +249,17 @@ in import_map.json
 }
 ```
 
-The packages in the standard library or those installed from `deno.land/x` will be removed from the cache.
+Removing from cache only works with standard packages and those installed from `deno.land/x`
 
-### install another version of a package
+### Selecting a specific version of a package
 
-write the name of the package more **@\<Version\>**
+Specify a package's version:
 
-example:
-
-```sh
-$ trex install --map fs@0.54.0
+```console
+trex install --map fs@0.54.0
 ```
 
-in import_map.json
+`import_map.json`
 
 ```json
 {
@@ -339,15 +271,13 @@ in import_map.json
 
 > **note**: can be used with third party packages.
 
-### check the versions of dependencies using
+### **Deprecated!** Verifying dependency versions
 
-## Deprecated!
-
-```sh
-$ trex --deps
+```console
+trex --deps
 ```
 
-you should see something like that on the console.
+For the following import map:
 
 ```json
 // in import_map.json
@@ -359,22 +289,25 @@ you should see something like that on the console.
 }
 ```
 
+The `--deps` flag prints out:
+
 | name  | module |                   url                   | version  |  latest  | upToDate |
 | :---: | :----: | :-------------------------------------: | :------: | :------: | :------: |
 |  oak  |  oak   | "https://deno.land/x/oak@v4.0.0/mod.ts" | "v4.0.0" | "v5.0.0" |  false   |
 | http/ |  std   |  "https://deno.land/std@0.54.0/http/"   | "0.54.0" | "0.54.0" |   true   |
 
-thanks to [Fzwael](https://github.com/Fzwael) this functionality is based on your tool [deno-check-updates](https://github.com/Fzwael/deno-check-updates)
+This functionality is based on the
+[deno-check-updates](https://github.com/Fzwael/deno-check-updates) tool by [Fzwael](https://github.com/Fzwael).
 
-### see pacakge dependency tree.
+### Checking a package's dependency tree
 
-```sh
-$ trex treeDeps fs
+```console
+trex treeDeps fs
 ```
 
-you should see this in the terminal
+This prints out something like:
 
-```sh
+```console
 local: C:\Users\trex\AppData\Local\deno\deps\https\deno.land\434fe4a7be02d187573484b382f4c1fec5b023d27d1dcf4f768f300799a073e0
 type: TypeScript
 compiled: C:\Users\trex\AppData\Local\deno\gen\https\deno.land\std\fs\mod.ts.js
@@ -445,31 +378,115 @@ https://deno.land/std/fs/mod.ts
 
 ### Integrity checking & lock files
 
-Let's say your module depends on remote module . When you compile your module for the first time is retrieved, compiled and cached. It will remain this way until you run your module on a new machine (say in production) or reload the cache (through for example). But what happens if the content in the remote url is changed? This could lead to your production module running with different dependency code than your local module. Deno's solution to avoid this is to use integrity checking and lock files.
+Let's say your module depends on a remote module.
+When you compile your module for the first time, it is retrieved, compiled and cached.
+It will remain this way until you run your module on a new machine (e.g. in production) or reload the cache.
 
-info from [deno page](https://deno.land/manual/linking_to_external_code/integrity_checking)
+But what happens if the content in the remote url is changed?
+This could lead to your production module running with different dependency code than your local module.
+Deno's solution to avoid this is to use integrity checking and lock files.
 
-**use:**
+Create a lockfile:
 
-```sh
-$ trex --lock file.ts
+```console
+trex --lock file.ts
 ```
 
-this generates a `lock.json` file.
+The above generates a `lock.json` file.
 
-if in input file you use `import_map.json` you can specify it.
+If you use `import_map.json` in input file, you can specify it:
 
-```sh
-$ trex --lock --importmap file.ts
+```console
+trex --lock --importmap file.ts
 ```
 
-for more information this is the [deno document](https://deno.land/manual/linking_to_external_code/integrity_checking)
+See [deno document](https://deno.land/manual/linking_to_external_code/integrity_checking) for more info.
 
-### Contributing
+## Complete example
 
-contributions are welcome, create a pull request and send us your feature, first check the [CONTRIBUTING GUIDELINES](CONTRIBUTING.md).
+### A simple std server
 
-### [LICENSE MIT](https://opensource.org/licenses/MIT)
+Install `http` and `fmt`:
+
+```console
+trex install --map http fmt
+```
+
+Create a simple server:
+
+```typescript
+// server.ts
+import { serve } from "http/server.ts";
+import { green } from "fmt/colors.ts";
+
+const server = serve({ port: 8000 });
+console.log(green("http://localhost:8000/"));
+
+for await (const req of server) {
+  req.respond({ body: "Hello World\n" });
+}
+```
+
+Run the server:
+
+```console
+deno run --allow-net --importmap=import_map.json --unstable server.ts
+```
+
+> **note**: it is important to use **--importmap=import_map.json --unstable**
+
+### Adding third party packages
+
+Example using [oak](https://deno.land/x/oak)
+
+Add the master version of oak:
+
+```console
+trex i --map oak
+```
+
+This adds `oak` to the `import_map.json` file:
+
+```json
+{
+  "imports": {
+    "http/": "https://deno.land/std/http/",
+    "fmt/": "https://deno.land/std/fmt/",
+    "oak": "https://deno.land/x/oak/mod.ts"
+  }
+}
+```
+
+> **note**: third party packages are added using **mod.ts**
+
+Then create an oak application. Note the `import` statement.
+
+```typescript
+// app.ts
+import { Application } from "oak";
+
+const app = new Application();
+
+app.use((ctx) => {
+  ctx.response.body = "Hello World!";
+});
+
+await app.listen({ port: 8000 });
+```
+
+Run the server:
+
+```console
+deno run --allow-net --importmap=import_map.json --unstable app.ts
+```
+
+## Contributing
+
+Contributions are welcome, see [CONTRIBUTING GUIDELINES](CONTRIBUTING.md).
+
+## Licensing
+
+Trex is licensed under the [MIT](https://opensource.org/licenses/MIT) license.
 
 </br>
  <p align="center">


### PR DESCRIPTION
Made some changes to ensure the README is comprehensible:

- Combined all usage instructions into the "Usage" section
- Moved the server and oak examples to the end as the "Complete example" section
- Reorganized headings
- Removed prompt `$` signs from cmdline snippets to simplify copying