### PR TITLE
Fix an error when command or flag is not defined

### DIFF
--- a/utils/logs.ts
+++ b/utils/logs.ts
@@ -120,7 +120,7 @@ export function HelpCommand({ command, flags }: HelpCommandParams) {
 export function CommandNotFound({ commands, flags }: CommandNotFoundParams) {
   const { args } = Deno;
 
-  const [command, flag, ..._] = args;
+  const [command  = '', flag = '', ..._] = args;
 
   if (!commands.includes(command)) {
     console.log(


### PR DESCRIPTION
This is noticeable when `trex` is executed without any arguments: 

![image](https://user-images.githubusercontent.com/44045911/96540793-2a2d2a80-12d1-11eb-9aa5-ba17f93b5600.png)

With this PR:

![image](https://user-images.githubusercontent.com/44045911/96540819-34e7bf80-12d1-11eb-98cf-d15672a76ae7.png)

---

An alternative fix is to modify this line so `trex` shows help text instead:

https://github.com/crewdevio/Trex/blob/1914a613b73f1dab5f15b4eafdf79da08a102337/cli.ts#L80

```diff
- else if (flags.help.includes(_arguments[0])) {
+ else if (flags.help.includes(_arguments[0]) || _arguments.length === 0) {
```