### PR TITLE
fix: trex command not found when there's not arguments

### DIFF
--- a/handlers/handle_packages.ts
+++ b/handlers/handle_packages.ts
@@ -160,7 +160,7 @@ export async function installPackages(args: string[]): Promise<objectGen> {
           const mod = pkg.split("/").join("");
           await cache(mod, await detectVersion(mod));
 
-          map[(await getNamePkg(mod)).toLowerCase()] = await detectVersion(mod);
+          map[(await getNamePkg(mod)).toLowerCase()] = md;
         }
 
         else {

--- a/utils/logs.ts
+++ b/utils/logs.ts
@@ -10,7 +10,7 @@ import type { CommandNotFoundParams, HelpCommandParams } from "./types.ts";
 import { didYouMean } from "../tools/did_you_mean.ts";
 import exec from "../tools/install_tools.ts";
 import { colors } from "../imports/fmt.ts";
-import { VERSION } from "./info.ts";
+import { helpsInfo, VERSION } from "./info.ts";
 
 const { cyan, red, green, yellow } = colors;
 
@@ -123,6 +123,11 @@ export function CommandNotFound({ commands, flags }: CommandNotFoundParams) {
 
   const [command = '', flag = ''] = args;
 
+  if (!args.length) {
+    LogHelp(helpsInfo);
+    Deno.exit(0);
+  }
+
   if (!commands.includes(command)) {
     console.log(
       red("Command not found:\n"),
@@ -136,7 +141,7 @@ export function CommandNotFound({ commands, flags }: CommandNotFoundParams) {
 
     console.log(didYouMean(command, commands));
 
-    Deno.exit(0);;
+    Deno.exit(0);
   }
 
   if (!flags.includes(flag)) {


### PR DESCRIPTION
closes #81 